### PR TITLE
Make 'driver' requirement non private

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
 # Copyright 2024 Zorxx Software. All rights reserved.
 idf_component_register(SRCS "dht.c"
                        INCLUDE_DIRS "."
-                       PRIV_REQUIRES "driver")
+                       REQUIRES "driver")


### PR DESCRIPTION
Hi, I was having issues using this component because the `driver` dependency is set in `PRIV_REQUIRES`, but [the documentation](https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-guides/build-system.html#when-writing-a-component) says it should be set in `REQUIRES`.

Dependencies used in the public header should be set in `REQUIRES` (unless I'm missing something, but this fixed the issue for me)